### PR TITLE
fix: GitHub Actions 쓰기 권한 추가

### DIFF
--- a/.github/workflows/run_sorter.yml
+++ b/.github/workflows/run_sorter.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   run-sorter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # 저장소에 푸시하기 위해 필요한 쓰기 권한
 
     steps:
       - name: Checkout code (Logic)


### PR DESCRIPTION
github-actions[bot]이 state-tracking 브랜치에 푸시할 수 있도록 contents: write 권한을 부여했습니다.