### PR TITLE
fix: state.json 저장 프로세스 안정화

### DIFF
--- a/.github/workflows/run_sorter.yml
+++ b/.github/workflows/run_sorter.yml
@@ -64,9 +64,19 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           
-          # 임시 브랜치를 만들어 state.json만 포함시킴
+          # state.json을 안전하게 복사해둡니다.
+          cp state.json state.json.tmp
+          
+          # 임시 브랜치를 만들어 히스토리를 끊습니다.
           git checkout --orphan temp-state
+          
+          # 인덱스와 작업 디렉토리의 모든 파일을 비웁니다.
           git rm -rf .
+          
+          # 복사해둔 파일을 다시 가져옵니다.
+          mv state.json.tmp state.json
+          
+          # state.json만 추가하고 커밋합니다.
           git add state.json
           git commit -m "chore: update state.json [skip ci]"
           


### PR DESCRIPTION
git rm -rf . 실행 전 state.json을 임시 보관하여 파일 유실을 방지합니다.